### PR TITLE
Lint and Deployment Errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,13 +37,22 @@
   ],
   "rules": {
     "@typescript-eslint/no-empty-function": "warn",
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "@typescript-eslint/no-unused-vars": "error",
     "no-console": ["error", { "allow": ["warn", "error"] }],
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": [
+          ["builtin", "external"],
+          "internal",
+          ["parent", "sibling", "index"]
+        ],
         "pathGroups": [
           {
             "pattern": "react",
@@ -51,7 +60,7 @@
             "position": "before"
           },
           {
-            "pattern": "@components/**",
+            "pattern": "@{components,config,hooks,lib,theme,types,utils,views}{**,**/**}",
             "group": "internal"
           },
           {

--- a/.eslintrc
+++ b/.eslintrc
@@ -60,31 +60,7 @@
             "position": "before"
           },
           {
-            "pattern": "@{components,config,hooks,lib,theme,types,utils,views}{**,**/**}",
-            "group": "internal"
-          },
-          {
-            "pattern": "@config/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "@hooks/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "@lib/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "@theme/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "@utils/**",
-            "group": "internal"
-          },
-          {
-            "pattern": "@views/**",
+            "pattern": "@{components,config,hooks,lib,theme,types,utils,views}/**",
             "group": "internal"
           }
         ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,12 @@
     ],
     "@typescript-eslint/no-unused-vars": "error",
     "no-console": ["error", { "allow": ["warn", "error"] }],
+    "import/first": "error",
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-self-import": "error",
+    "import/no-useless-path-segments": "error",
     "import/order": [
       "error",
       {
@@ -73,6 +79,14 @@
       }
     ],
     "import/no-anonymous-default-export": [2, { "allowArrowFunction": true }],
-    "import/no-unresolved": "error"
+    "import/no-unresolved": "error",
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": true,
+        "ignoreDeclarationSort": true,
+        "allowSeparatedGroups": true
+      }
+    ]
   }
 }

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-bash ./check-branch.sh && yarn test
+bash ./check-branch.sh && yarn test && yarn build

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
   "bracketSpacing": true,
   "printWidth": 80,
   "useTabs": false,
-  "endOfLine": "crlf",
   "arrowParens": "avoid"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,12 @@
     "[ ]",
     "[x]"
   ],
-  "cSpell.words": ["commitlint", "devmoji", "samen"]
+  "cSpell.words": ["commitlint", "devmoji", "samen"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.tabSize": 2,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.requireConfig": true,
+  "prettier.useEditorConfig": false
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Getting Started
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 First, run the development server:

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,6 @@
 import { ColorModeScript } from '@chakra-ui/react'
 /* eslint-disable @next/next/no-document-import-in-page */
-import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
+import NextDocument, { Head, Html, Main, NextScript } from 'next/document'
 
 import theme from '@theme'
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,12 @@
 import {
+  AspectRatio,
   Box,
   Button,
   Heading,
   SimpleGrid,
   Spinner,
-  VStack,
   Text,
-  AspectRatio,
+  VStack,
 } from '@chakra-ui/react'
 import { GetStaticProps } from 'next'
 import { useTranslation } from 'next-i18next'

--- a/src/components/CardBox/index.tsx
+++ b/src/components/CardBox/index.tsx
@@ -1,15 +1,16 @@
 import {
   Box,
-  Heading,
-  VStack,
-  Text,
   Button,
   ChakraProps,
+  Heading,
+  Text,
+  VStack,
 } from '@chakra-ui/react'
 import { format } from 'date-fns'
 import { useTranslation } from 'next-i18next'
 
 import { ChakraNextImage, Navigate } from '@components'
+
 interface CardBoxProps extends ChakraProps {
   item: SubpageType
   href: string

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Link } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 import NextImage from 'next/image'
 
-import { Container, HeaderTop, HeaderNav } from '@components'
+import { Container, HeaderNav, HeaderTop } from '@components'
 
 export const Header = (): JSX.Element => {
   return (

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react'
 
-import { Flex, Box } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
 import { NextSeo } from 'next-seo'
 
-import { Header, Footer } from '@components'
+import { Footer, Header } from '@components'
 import { getImageUrl } from '@utils'
 
 interface LayoutProps {

--- a/src/components/Navigate/index.tsx
+++ b/src/components/Navigate/index.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from 'react'
 
 import {
-  Link,
-  forwardRef,
-  ChakraProps,
   ChakraComponent,
+  ChakraProps,
+  forwardRef,
+  Link,
 } from '@chakra-ui/react'
 import NextLink from 'next/link'
 

--- a/src/components/SocialButtons/index.tsx
+++ b/src/components/SocialButtons/index.tsx
@@ -26,11 +26,7 @@ const SocialButton = ({
 type SocialLinkType = {
   label: string
   icon: IconType
-  link: {
-    en: string
-    tr: string
-    nl: string
-  }
+  link: Record<string, string>
 }
 const SOCIAL_LINKS: SocialLinkType[] = [
   {
@@ -79,7 +75,7 @@ export const SocialButtons = (): JSX.Element => {
           key={i}
           icon={item.icon}
           label={item.label}
-          href={item.link[locale]}
+          href={item.link[locale as string]}
         />
       ))}
     </HStack>

--- a/src/components/SocialButtons/index.tsx
+++ b/src/components/SocialButtons/index.tsx
@@ -1,7 +1,8 @@
-import { IconButton, HStack } from '@chakra-ui/react'
+import { HStack, IconButton } from '@chakra-ui/react'
 import { useRouter } from 'next/router'
 import { FaFacebook, FaInstagram, FaTwitter, FaYoutube } from 'react-icons/fa'
 import { IconType } from 'react-icons/lib'
+
 const SocialButton = ({
   icon: Icon,
   href,

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,5 +1,5 @@
-import { Theme, Colors } from '@chakra-ui/react'
-import { lighten, darken } from '@chakra-ui/theme-tools'
+import { Colors, Theme } from '@chakra-ui/react'
+import { darken, lighten } from '@chakra-ui/theme-tools'
 
 const generateColorPalette = (color: string, theme: Theme): Colors => ({
   50: lighten(color, 45)(theme),

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,7 +1,7 @@
 import {
-  extendTheme,
   theme as chakraTheme,
   DeepPartial,
+  extendTheme,
   ThemeConfig,
 } from '@chakra-ui/react'
 

--- a/src/views/ApplicationView/index.tsx
+++ b/src/views/ApplicationView/index.tsx
@@ -18,7 +18,7 @@ export const ApplicationView = ({
   source,
 }: ApplicationProps): JSX.Element => {
   const { locale } = useRouter()
-  const [, , currentSlug] = slug[locale!]
+  const [, , currentSlug] = slug[locale as string]
 
   const { data } = useData<ApplicationType[]>('applications', {
     slug: currentSlug,
@@ -33,7 +33,7 @@ export const ApplicationView = ({
     <Box p={4} boxShadow="lg">
       <h1>{application.title}</h1>
       <Markdown source={source} />
-      <ChakraNextImage image={application.image} />
+      {application.image && <ChakraNextImage image={application.image} />}
     </Box>
   )
 }

--- a/src/views/TweetView/index.tsx
+++ b/src/views/TweetView/index.tsx
@@ -20,7 +20,7 @@ export const TweetView = ({ slug }: TweetProps): JSX.Element => {
   return (
     <div>
       <p>{tweet?.tweet}</p>
-      <ChakraNextImage image={tweet.image} />
+      {tweet.image && <ChakraNextImage image={tweet.image} />}
     </div>
   )
 }


### PR DESCRIPTION
**Description**

- I've noticed that prettier's `endOfLine` rule was causing conflicts on different platforms (windows/osx). To solve this problem I applied [this solution](https://stackoverflow.com/a/53769213/8206907)
- Updated vscode workspace settings
- Another issue I've encountered is that if image is not provided from strapi backend `ChakraNextImage` component throws error. As a solution, I render this component conditionally.
- Included build script as pre-push hook which means it won't allow to push if there will be any build error.
- Finally, improved [sorting import lint rules](https://eslint.org/docs/rules/sort-imports#ignoremembersort). It might not important actually but just wanted to have after noticing this feature.